### PR TITLE
Add min-height to the code editor

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -26,6 +26,7 @@
   overflow: auto;
   margin-top: 0.5rem;
   position: relative;
+  min-height: 12rem
 }
 
 .CodeColumnLeft,


### PR DESCRIPTION
First of all thank you for this!

This fix is needed as the code editor gets hidden if there are a lot of tasks and they take up the screen height.

<img width="1003" alt="Screenshot 2022-01-09 at 3 01 37 PM" src="https://user-images.githubusercontent.com/6652823/148676865-793b8222-7220-4576-a83d-21bc2ae8fa07.png">
