### PR TITLE
Replace jsurl2 with btoa

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,26 @@ If you like this project ☕️ buy me a cup of coffee at [patreon.com/bvaughn](
 
 ## Examples
 
-### [View years example](https://plannerjs.dev/?(tasks~!(start~*2022-01-01~stop~*2022-06-30~name~H1_2022)(start~*2022-07-01~stop~*2022-12-31~name~H2_2022)(start~*2023-01-01~stop~*2023-06-30~name~H1_2023)(start~*2022-01-01~stop~*2022-12-31~name~*2022~owner~Other_team)~team~())~)
+### [View years example](https://plannerjs.dev/?data=eyJ0YXNrcyI6W3sic3RhcnQiOiIyMDIyLTAxLTAxIiwic3RvcCI6IjIwMjItMTItMzEiLCJuYW1lIjoiMjAyMiIsIm93bmVyIjoiT3RoZXIgdGVhbSJ9LHsic3RhcnQiOiIyMDIyLTAxLTAxIiwic3RvcCI6IjIwMjItMDYtMzAiLCJuYW1lIjoiSDEgMjAyMiJ9LHsic3RhcnQiOiIyMDIyLTA3LTAxIiwic3RvcCI6IjIwMjItMTItMzEiLCJuYW1lIjoiSDIgMjAyMiJ9LHsic3RhcnQiOiIyMDIzLTAxLTAxIiwic3RvcCI6IjIwMjMtMDYtMzAiLCJuYW1lIjoiSDEgMjAyMyJ9XSwidGVhbSI6e319)
 
-<img width="1004" alt="Planner screenshot" src="https://user-images.githubusercontent.com/29597/148121007-ffa0c1c7-48b5-452d-8d5a-b8e722b45163.png">
+![Planner screenshot](https://user-images.githubusercontent.com/29597/148847931-204e6743-e3e9-448a-a5f9-94d84949833b.png)
 
-### [View months example](https://plannerjs.dev/?(tasks~!(id~example~name~Design_API~owner~bvaughn~start~*2022-01-01~stop~*2022-03-15)(id~0~name~Write_API_documentation~owner~susan~start~*2022-03-01~stop~*2022-05-01~dependency~example)(id~1~name~Support_product_team_integration~owner~bvaughn~start~*2022-03-15~stop~*2022-05-15~isOngoing~~dependency~example)(id~2~name~Finish_project_carryover~owner~susan~start~*2022-01-01~stop~*2022-03-01)(id~3~name~GitHub_issue_support~owner~team~start~*2022-03-01~stop~*2022-04-01~isOngoing)~team~(bvaughn~(avatar~https://avatars.githubusercontent.com/u/29597~name~Brian)team~(avatar~_N~name~Unclaimed)))~)
+### [View months example](https://plannerjs.dev/?data=eyJ0YXNrcyI6W3siaWQiOiJleGFtcGxlIiwibmFtZSI6IkRlc2lnbiBBUEkiLCJvd25lciI6ImJ2YXVnaG4iLCJzdGFydCI6IjIwMjItMDEtMDEiLCJzdG9wIjoiMjAyMi0wMy0xNSJ9LHsiaWQiOjIsIm5hbWUiOiJGaW5pc2ggcHJvamVjdCBjYXJyeW92ZXIiLCJvd25lciI6InN1c2FuIiwic3RhcnQiOiIyMDIyLTAxLTAxIiwic3RvcCI6IjIwMjItMDMtMDEifSx7ImlkIjowLCJuYW1lIjoiV3JpdGUgQVBJIGRvY3VtZW50YXRpb24iLCJvd25lciI6InN1c2FuIiwic3RhcnQiOiIyMDIyLTAzLTAxIiwic3RvcCI6IjIwMjItMDUtMDEiLCJkZXBlbmRlbmN5IjoiZXhhbXBsZSJ9LHsiaWQiOjMsIm5hbWUiOiJHaXRIdWIgaXNzdWUgc3VwcG9ydCIsIm93bmVyIjoidGVhbSIsInN0YXJ0IjoiMjAyMi0wMy0wMSIsInN0b3AiOiIyMDIyLTA0LTAxIiwiaXNPbmdvaW5nIjp0cnVlfSx7ImlkIjoxLCJuYW1lIjoiU3VwcG9ydCBwcm9kdWN0IHRlYW0gaW50ZWdyYXRpb24iLCJvd25lciI6ImJ2YXVnaG4iLCJzdGFydCI6IjIwMjItMDMtMTUiLCJzdG9wIjoiMjAyMi0wNS0xNSIsImlzT25nb2luZyI6dHJ1ZSwiZGVwZW5kZW5jeSI6ImV4YW1wbGUifV0sInRlYW0iOnsiYnZhdWdobiI6eyJhdmF0YXIiOm51bGwsIm5hbWUiOiJCcmlhbiJ9LCJ0ZWFtIjp7ImF2YXRhciI6bnVsbCwibmFtZSI6IlVuY2xhaW1lZCJ9fX0)
 
-<img width="1004" alt="Planner screenshot" src="https://user-images.githubusercontent.com/29597/148121010-6b1c5e1d-d6ab-4159-89ca-61a050c40823.png">
+![Planner screenshot](https://user-images.githubusercontent.com/29597/148847915-e3089665-8939-4265-bb63-44c35a7d93d1.png)
 
-### [View weeks example](https://plannerjs.dev/?(tasks~!(name~Week_A~start~*2022-01-03~stop~*2022-01-09~owner~Erin)(name~Week_B~start~*2022-01-10~stop~*2022-01-23~owner~Erin)(name~Week_C~start~*2022-01-17~stop~*2022-01-23~owner~Chris)~team~())~)
+### [View weeks example](https://plannerjs.dev/?data=eyJ0YXNrcyI6W3sibmFtZSI6IldlZWsgQSIsInN0YXJ0IjoiMjAyMi0wMS0wMyIsInN0b3AiOiIyMDIyLTAxLTA5Iiwib3duZXIiOiJFcmluIn0seyJuYW1lIjoiV2VlayBCIiwic3RhcnQiOiIyMDIyLTAxLTEwIiwic3RvcCI6IjIwMjItMDEtMjMiLCJvd25lciI6IkVyaW4ifSx7Im5hbWUiOiJXZWVrIEMiLCJzdGFydCI6IjIwMjItMDEtMTciLCJzdG9wIjoiMjAyMi0wMS0yMyIsIm93bmVyIjoiQ2hyaXMifV0sInRlYW0iOnt9fQ)
 
-<img width="1004" alt="Planner screenshot" src="https://user-images.githubusercontent.com/29597/148121011-90ed264b-e8be-4455-a6aa-9041dec8db58.png">
+![Planner screenshot](https://user-images.githubusercontent.com/29597/148847895-213f4307-6d9b-497d-9b7a-9e6fb5dd9e85.png)
 
-### [View days example](http://plannerjs.dev/?(tasks~!(start~*2022-02-12~stop~*2022-02-13~name~Spring_cleaning~owner~timeoff)(start~*2022-02-14~stop~*2022-02-17~name~Work~owner~pro)~team~(pro~(name~Professional_Brian)timeoff~(name~Time_off_Brian)))~)
+### [View days example](https://plannerjs.dev/?data=eyJ0YXNrcyI6W3sic3RhcnQiOiIyMDIyLTAyLTEyIiwic3RvcCI6IjIwMjItMDItMTMiLCJuYW1lIjoiU3ByaW5nIGNsZWFuaW5nIiwib3duZXIiOiJ0aW1lb2ZmIn0seyJzdGFydCI6IjIwMjItMDItMTQiLCJzdG9wIjoiMjAyMi0wMi0xNyIsIm5hbWUiOiJXb3JrIiwib3duZXIiOiJwcm8ifV0sInRlYW0iOnsicHJvIjp7Im5hbWUiOiJQcm9mZXNzaW9uYWwgQnJpYW4ifSwidGltZW9mZiI6eyJuYW1lIjoiVGltZSBvZmYgQnJpYW4ifX19)
 
-<img width="1004" alt="Planner screenshot" src="https://user-images.githubusercontent.com/29597/148121012-8529e903-1476-46b6-80ab-3996d3b88288.png">
+![Planner screenshot](https://user-images.githubusercontent.com/29597/148847859-cace24e7-e25d-4149-b191-14f9209959b0.png)
+
+---
+
+## Converting legacy plans
+
+Planner switched from [jsurl2](https://npmjs.com/package/jsurl2) to Base64 encoding due to URL parsing problems jsurl2 caused websites like Twitter. If you created a plan with using the old jsurl2 encoding, you can migrate to the new format at the URL below:
+
+https://plannerjs.dev/api/convert?(your-data-here)

--- a/__tests__/url-utils.js
+++ b/__tests__/url-utils.js
@@ -1,4 +1,4 @@
-const { stringify } = require("jsurl2");
+const btoa = require("btoa");
 
 const PUBLIC_URL = "http://localhost:3000";
 
@@ -11,7 +11,11 @@ function getUrlForData(data) {
 function getUrlForOgImage(data) {
   const stringified = stringify(data);
 
-  return `${PUBLIC_URL}/api/ogimage/?${stringified}`;
+  return `${PUBLIC_URL}/api/ogimage/?data=${stringified}`;
+}
+
+function stringify(data) {
+  return btoa(JSON.stringify(data));
 }
 
 module.exports = {

--- a/components/hooks/useURLData.js
+++ b/components/hooks/useURLData.js
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useSyncExternalStore } from "react";
-import { parse, stringify } from "jsurl2";
 import history from "history/browser";
 import { saveSearchToHistory, subscribeToHistory } from "../utils/history";
+import { parse, stringify } from "../utils/url";
 
 function getSnapshot() {
   try {
@@ -26,7 +26,7 @@ function saveToOgImage(stringified) {
     return;
   }
 
-  const url = `${window.location.protocol}//${window.location.host}/api/ogimage/?${stringified}`;
+  const url = `${window.location.protocol}//${window.location.host}/api/ogimage/?data=${stringified}`;
 
   const ogImage = document.head.querySelector('[property="og:image"]');
   if (ogImage) {
@@ -48,7 +48,7 @@ export default function useURLData(defaultData) {
   const data = useMemo(() => {
     if (snapshotString) {
       try {
-        const parsed = parse(snapshotString, { deURI: true });
+        const parsed = parse(snapshotString);
 
         // Parsed value should be an object.
         // If it's still a string then parsing was unsuccessful.

--- a/components/utils/history.js
+++ b/components/utils/history.js
@@ -21,11 +21,6 @@ export function saveSearchToHistory(newSearch) {
     // Remove the leading "?"
     prevSearch = prevSearch.substr(1);
 
-    // Nested apostrophes are auto escaped by the "history" library,
-    // e.g. "jsurl2" serializes `team's` to `team*"s` which "history" converts to `team*%22s`.
-    // We need to manually undo this conversion before comparing new search strings to current ones.
-    prevSearch = prevSearch.replace(/\*%22/g, '*"');
-
     // Don't push a new History entry if the search string hasn't changed.
     if (prevSearch === newSearch) {
       return;

--- a/components/utils/url.js
+++ b/components/utils/url.js
@@ -1,0 +1,7 @@
+export function parse(string) {
+  return JSON.parse(atob(string));
+}
+
+export function stringify(data) {
+  return btoa(JSON.stringify(data));
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^12.0.7",
+    "btoa": "^1.2.1",
     "eslint": "^8.6.0",
     "eslint-config-next": "12.0.7",
     "next": "latest",

--- a/pages/api/convert.js
+++ b/pages/api/convert.js
@@ -1,0 +1,20 @@
+import btoa from "btoa";
+import { createServer } from "http";
+import { parse as decode } from "jsurl2";
+import { parse } from "url";
+import { stringify } from "../../components/utils/url";
+
+export default async function handler(req, res) {
+  const parsedUrl = parse(req.url, true);
+  const { pathname, search } = parsedUrl;
+
+  // Convert from the old format, which serialized data using "jsurl2"
+  // to the new format which uses Base64
+  const decoded = decode(search.substr(1));
+  const encoded = btoa(JSON.stringify(decoded));
+
+  res.writeHead(302, {
+    Location: `/?${encoded}`,
+  });
+  res.end();
+}

--- a/pages/api/ogimage.js
+++ b/pages/api/ogimage.js
@@ -44,7 +44,7 @@ export default async function handler(req, res) {
     "Cache-Control": "no-cache",
   });
 
-  const url = `${URL}/headless?${search.substr(1)}`;
+  const url = `${URL}/headless${search}`;
   console.log(`Requesting URL "${url}"`);
 
   const [_, response] = await Promise.all([

--- a/pages/headless/Headless.js
+++ b/pages/headless/Headless.js
@@ -1,7 +1,7 @@
-import { parse } from "jsurl2";
 import { useRouter } from "next/router";
 import Legend from "../../components/Legend";
 import Planner from "../../components/Planner";
+import { parse } from "../../components/utils/url";
 import * as defaultConfig from "../../components/Planner/defaultConfig";
 import styles from "./headless.module.css";
 
@@ -19,11 +19,15 @@ Object.entries(defaultConfig).forEach(([key, value]) => {
   }
 });
 
-const OUTER_STYLE = {
+const OUTER_STYLE_CROPPED = {
   padding: `${OG_IMAGE_MARGIN}px`,
   width: OG_IMAGE_WIDTH,
-  height: OG_IMAGE_HEIGHT,
   fontSize: `${SCALED_CONFIG.FONT_SIZE_NORMAL}px`,
+};
+
+const OUTER_STYLE = {
+  ...OUTER_STYLE_CROPPED,
+  height: OG_IMAGE_HEIGHT,
 };
 
 const INNER_STYLE = {
@@ -32,19 +36,24 @@ const INNER_STYLE = {
 };
 
 export default function Headless() {
-  const { query } = useRouter();
+  const {
+    query: { cropped, data },
+  } = useRouter();
 
-  const keys = Object.keys(query);
-  if (keys.length === 0) {
+  if (!data) {
     return null;
   }
 
-  const { tasks, team } = parse(keys[0], { deURI: true });
+  const { tasks, team } = parse(data);
 
   const scale = window.devicePixelRatio;
 
   return (
-    <div id="ogImageContainer" className={styles.Container} style={OUTER_STYLE}>
+    <div
+      id="ogImageContainer"
+      className={styles.Container}
+      style={cropped ? OUTER_STYLE_CROPPED : OUTER_STYLE}
+    >
       <div>
         <Legend
           avatarSize={SCALED_CONFIG.AVATAR_SIZE}

--- a/pages/test/index.js
+++ b/pages/test/index.js
@@ -13,7 +13,7 @@ export default function Test() {
       <ul>
         {Object.entries(URLS).map(([name, query]) => (
           <li key={name}>
-            <Link href={`/headless?${query}`}>{name}</Link>
+            <Link href={`/headless?data=${query}`}>{name}</Link>
           </li>
         ))}
       </ul>
@@ -21,7 +21,7 @@ export default function Test() {
       <ul>
         {Object.entries(URLS).map(([name, query]) => (
           <li key={name}>
-            <Link href={`/api/ogimage/?${query}`}>{name}</Link>
+            <Link href={`/api/ogimage/?data=${query}`}>{name}</Link>
           </li>
         ))}
       </ul>
@@ -30,9 +30,9 @@ export default function Test() {
 }
 
 const URLS = {
-  default: `(tasks~!(id~1~start~*2022-01-01~stop~*2022-03-15~name~Planner_JS~owner~planner)(start~*2022-01-15~stop~*2022-05-30~name~Plan_and_share_your_next_project_in_minutes~isOngoing~~owner~team)(start~*2022-02-01~stop~*2022-05-01~name~Lightweight_ightweight_planning_tool~dependency~1~owner~planner)~team~(planner~(name~Planner_JS~color~**H543e5b~avatar~*/static/avatar.png)team~(name~Your_team~color~**H22223B)))~`,
-  days: `(tasks~!(start~*2022-02-12~stop~*2022-02-13~name~Spring_cleaning~owner~timeoff)(start~*2022-02-14~stop~*2022-02-17~name~Work~owner~pro)~team~(pro~(name~Professional_Brian)timeoff~(name~Time_off_Brian)))~)`,
-  weeks: `(tasks~!(name~Week_A~start~*2022-01-03~stop~*2022-01-09~owner~Erin)(name~Week_B~start~*2022-01-10~stop~*2022-01-23~owner~Erin)(name~Week_C~start~*2022-01-17~stop~*2022-01-23~owner~Chris)~team~())~)`,
-  months: `(tasks~!(id~example~name~Design_API~owner~bvaughn~start~*2022-01-01~stop~*2022-03-15)(id~0~name~Write_API_documentation~owner~susan~start~*2022-03-01~stop~*2022-05-01~dependency~example)(id~1~name~Support_product_team_integration~owner~bvaughn~start~*2022-03-15~stop~*2022-05-15~isOngoing~~dependency~example)(id~2~name~Finish_project_carryover~owner~susan~start~*2022-01-01~stop~*2022-03-01)(id~3~name~GitHub_issue_support~owner~team~start~*2022-03-01~stop~*2022-04-01~isOngoing)~team~(bvaughn~(avatar~_N~name~Brian)team~(avatar~_N~name~Unclaimed)))~)`,
-  years: `(tasks~!(start~*2022-01-01~stop~*2022-06-30~name~H1_2022)(start~*2022-07-01~stop~*2022-12-31~name~H2_2022)(start~*2023-01-01~stop~*2023-06-30~name~H1_2023)(start~*2022-01-01~stop~*2022-12-31~name~*2022~owner~Other_team)~team~())~`,
+  default: `eyJ0YXNrcyI6W3siaWQiOjEsInN0YXJ0IjoiMjAyMi0wMS0wMSIsInN0b3AiOiIyMDIyLTAzLTE1IiwibmFtZSI6IlBsYW5uZXIgSlMiLCJvd25lciI6InBsYW5uZXIifSx7InN0YXJ0IjoiMjAyMi0wMS0xNSIsInN0b3AiOiIyMDIyLTA1LTMwIiwibmFtZSI6IlBsYW4gYW5kIHNoYXJlIHlvdXIgbmV4dCBwcm9qZWN0IGluIG1pbnV0ZXMiLCJpc09uZ29pbmciOnRydWUsIm93bmVyIjoidGVhbSJ9LHsic3RhcnQiOiIyMDIyLTAyLTAxIiwic3RvcCI6IjIwMjItMDUtMDEiLCJuYW1lIjoiTGlnaHR3ZWlnaHQgaWdodHdlaWdodCBwbGFubmluZyB0b29sIiwiZGVwZW5kZW5jeSI6MSwib3duZXIiOiJwbGFubmVyIn1dLCJ0ZWFtIjp7InBsYW5uZXIiOnsibmFtZSI6IlBsYW5uZXIgSlMiLCJjb2xvciI6IiM1NDNlNWIiLCJhdmF0YXIiOiIvc3RhdGljL2F2YXRhci5wbmcifSwidGVhbSI6eyJuYW1lIjoiWW91ciB0ZWFtIiwiY29sb3IiOiIjMjIyMjNCIn19fQ`,
+  days: `eyJ0YXNrcyI6W3sic3RhcnQiOiIyMDIyLTAyLTEyIiwic3RvcCI6IjIwMjItMDItMTMiLCJuYW1lIjoiU3ByaW5nIGNsZWFuaW5nIiwib3duZXIiOiJ0aW1lb2ZmIn0seyJzdGFydCI6IjIwMjItMDItMTQiLCJzdG9wIjoiMjAyMi0wMi0xNyIsIm5hbWUiOiJXb3JrIiwib3duZXIiOiJwcm8ifV0sInRlYW0iOnsicHJvIjp7Im5hbWUiOiJQcm9mZXNzaW9uYWwgQnJpYW4ifSwidGltZW9mZiI6eyJuYW1lIjoiVGltZSBvZmYgQnJpYW4ifX19`,
+  weeks: `eyJ0YXNrcyI6W3sibmFtZSI6IldlZWsgQSIsInN0YXJ0IjoiMjAyMi0wMS0wMyIsInN0b3AiOiIyMDIyLTAxLTA5Iiwib3duZXIiOiJFcmluIn0seyJuYW1lIjoiV2VlayBCIiwic3RhcnQiOiIyMDIyLTAxLTEwIiwic3RvcCI6IjIwMjItMDEtMjMiLCJvd25lciI6IkVyaW4ifSx7Im5hbWUiOiJXZWVrIEMiLCJzdGFydCI6IjIwMjItMDEtMTciLCJzdG9wIjoiMjAyMi0wMS0yMyIsIm93bmVyIjoiQ2hyaXMifV0sInRlYW0iOnt9fQ`,
+  months: `eyJ0YXNrcyI6W3siaWQiOiJleGFtcGxlIiwibmFtZSI6IkRlc2lnbiBBUEkiLCJvd25lciI6ImJ2YXVnaG4iLCJzdGFydCI6IjIwMjItMDEtMDEiLCJzdG9wIjoiMjAyMi0wMy0xNSJ9LHsiaWQiOjIsIm5hbWUiOiJGaW5pc2ggcHJvamVjdCBjYXJyeW92ZXIiLCJvd25lciI6InN1c2FuIiwic3RhcnQiOiIyMDIyLTAxLTAxIiwic3RvcCI6IjIwMjItMDMtMDEifSx7ImlkIjowLCJuYW1lIjoiV3JpdGUgQVBJIGRvY3VtZW50YXRpb24iLCJvd25lciI6InN1c2FuIiwic3RhcnQiOiIyMDIyLTAzLTAxIiwic3RvcCI6IjIwMjItMDUtMDEiLCJkZXBlbmRlbmN5IjoiZXhhbXBsZSJ9LHsiaWQiOjMsIm5hbWUiOiJHaXRIdWIgaXNzdWUgc3VwcG9ydCIsIm93bmVyIjoidGVhbSIsInN0YXJ0IjoiMjAyMi0wMy0wMSIsInN0b3AiOiIyMDIyLTA0LTAxIiwiaXNPbmdvaW5nIjp0cnVlfSx7ImlkIjoxLCJuYW1lIjoiU3VwcG9ydCBwcm9kdWN0IHRlYW0gaW50ZWdyYXRpb24iLCJvd25lciI6ImJ2YXVnaG4iLCJzdGFydCI6IjIwMjItMDMtMTUiLCJzdG9wIjoiMjAyMi0wNS0xNSIsImlzT25nb2luZyI6dHJ1ZSwiZGVwZW5kZW5jeSI6ImV4YW1wbGUifV0sInRlYW0iOnsiYnZhdWdobiI6eyJhdmF0YXIiOm51bGwsIm5hbWUiOiJCcmlhbiJ9LCJ0ZWFtIjp7ImF2YXRhciI6bnVsbCwibmFtZSI6IlVuY2xhaW1lZCJ9fX0`,
+  years: `eyJ0YXNrcyI6W3sic3RhcnQiOiIyMDIyLTAxLTAxIiwic3RvcCI6IjIwMjItMTItMzEiLCJuYW1lIjoiMjAyMiIsIm93bmVyIjoiT3RoZXIgdGVhbSJ9LHsic3RhcnQiOiIyMDIyLTAxLTAxIiwic3RvcCI6IjIwMjItMDYtMzAiLCJuYW1lIjoiSDEgMjAyMiJ9LHsic3RhcnQiOiIyMDIyLTA3LTAxIiwic3RvcCI6IjIwMjItMTItMzEiLCJuYW1lIjoiSDIgMjAyMiJ9LHsic3RhcnQiOiIyMDIzLTAxLTAxIiwic3RvcCI6IjIwMjMtMDYtMzAiLCJuYW1lIjoiSDEgMjAyMyJ9XSwidGVhbSI6e319`,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1137,6 +1137,11 @@ browserslist@^4.17.5:
     node-releases "^2.0.1"
     picocolors "^1.0.0"
 
+btoa@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.2.1.tgz#01a9909f8b2c93f6bf680ba26131eb30f7fa3d73"
+  integrity sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==
+
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"


### PR DESCRIPTION
jsurl2 caused URL parsing problems on websites like Twitter.

To help ease this transition, I've added a migration route: /api/migrate/?...

Pass old data to this API for a redirect to the new data format.