### PR TITLE
Fix duplicate entries in legend due to case sensitive owner key

### DIFF
--- a/components/Legend/Legend.js
+++ b/components/Legend/Legend.js
@@ -26,7 +26,7 @@ export default function Legend({ avatarSize = 24, tasks, team }) {
 
     for (let taskIndex = 0; taskIndex < tasks.length; taskIndex++) {
       const task = tasks[taskIndex];
-      const ownerKey = task.owner || "Team";
+      const ownerKey = (task.owner || "Team").toLowerCase();
       if (!map.has(ownerKey)) {
         map.set(ownerKey, {
           name: ownerKey.toLowerCase(),


### PR DESCRIPTION
👋 Fixing a small bug I noticed, if you have a key that is not all lowercase in the owners object, it leads to having duplicate entries in the legend:

### Before:
<img width="1793" alt="Screen Shot 2022-01-12 at 2 09 04 PM" src="https://user-images.githubusercontent.com/1416436/149205883-a8ad69f5-15ac-4ed3-b29d-3dc2ac5d6bb6.png">

(Notice how there are two "Planner" entries in the legend)

### After:
<img width="1793" alt="Screen Shot 2022-01-12 at 2 07 57 PM" src="https://user-images.githubusercontent.com/1416436/149205791-2c94b719-2365-47cb-b9ff-635a6432dfb5.png">

(No more duplicate entries 🎉 )